### PR TITLE
Add Privacy Policy page and link in footer

### DIFF
--- a/src/_includes/components/footer.liquid
+++ b/src/_includes/components/footer.liquid
@@ -16,6 +16,9 @@
             <a href="/structure/#support-our-work">Support us</a>
           </li>
           <li>
+            <a href="/privacy-policy/">Privacy Policy</a>
+          </li>
+          <li>
             <a href="/impressum/">Impressum</a>
           </li>
           <li>

--- a/src/assets/css/pages/agreement.css
+++ b/src/assets/css/pages/agreement.css
@@ -1,7 +1,8 @@
 /* User research agreement section */
 
 #agreement-intro,
-#data-use-intro {
+#data-use-intro,
+#privacy-intro {
   padding-top: 150px;
   padding-bottom: 50px;
 }
@@ -15,7 +16,8 @@
 }
 
 #agreement-intro h1,
-#data-use-intro h1 {
+#data-use-intro h1,
+#privacy-intro h1 {
   font-family: Biotif;
   font-size: 56px;
   line-height: 1.1;
@@ -25,7 +27,8 @@
 
 @media (max-width: 767px) {
   #agreement-intro h1,
-  #data-use-intro h1 {
+  #data-use-intro h1,
+  #privacy-intro h1 {
     margin-left: -24px;
     margin-right: -24px;
     font-size: 56px;

--- a/src/privacy-policy.html
+++ b/src/privacy-policy.html
@@ -1,0 +1,400 @@
+---
+layout: base
+title: Privacy Policy
+---
+
+<div class="bg-gradient-agreement-header">
+  <section id="privacy-intro">
+    <div class="container">
+      <div class="poly">{% include 'svg/poly/poly-thin.svg' %}</div>
+      <div class="grid">
+        <div class="content col-s-12 col-m-8 col-m-offset-3">
+          <h1 class="text-center mb-48">
+            Privacy Policy
+          </h1>
+          <h2 class="text-center mb-32">Summary</h2>
+          <p class="text-center mb-24">
+            We, the Open Home Foundation, Grabenstrasse 25, 6340 Baar, Switzerland, are the operator of the website <a
+              style="color: inherit;font-weight:600" href="https://www.openhomefoundation.org/">https://www.openhomefoundation.org/</a>
+            and are responsible for the data processing described in this privacy policy, unless stated otherwise below.
+          </p>
+          <p class="text-center mb-24">
+            Privacy is one of the Open Home Foundation's three fundamental <a style="color: inherit;font-weight:600"
+              href="https://www.openhomefoundation.org/">principles</a> that are at the core of everything we do. It is
+            therefore that we collect as minimal of data as possible and where we do, we do this with a preference of
+            self-hosted and/or privacy focused tools.
+          </p>
+          <p class="text-center mb-24">
+            Please note that this Privacy Policy is applicable only to the Open Home Foundation official website, hosted
+            at openhomefoundation.org, and any activities that are provided directly from this website domain such as
+            email contact, our newsletter or participation in one of our research activities.
+          </p>
+          <p class="text-center mb-24">
+            Products/projects (such as Home Assistant, ESPHome and Music Assistant) of the Open Home Foundation and
+            their respective websites have their own Privacy Policy or have one in the making (where applicable) but
+            these are out of scope for this document.
+          </p>
+          <p class="text-center mb-24">
+            In order to provide the website and enable you to use its features and services, we do need to collect some
+            personal data from you, such as your IP-address or your contact details in case you contact us.
+          </p>
+          <p class="text-center mb-48">
+            As we operate from Switzerland, we comply with the Swiss Federal Act on Data Protection (FADP) as well as the
+            EU General Data Protection Regulation (GDPR) for our website visitors and customers in the European Economic
+            Area.
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="privacy-data-processing">
+    <div class="container">
+      <div class="grid">
+        <div class="col-s-12 col-m-8 col-m-offset-3">
+          <h2 class="text-center mb-48">Data Processing Activities</h2>
+
+          <h3 class="text-center mb-24">Contacting us</h3>
+          <p class="text-center mb-24">
+            If you contact us via email or through any contact channels provided on the website, your personal data will
+            be processed. We process the data you provide us with, such as your name, email address and/or phone number
+            and the content of your inquiry. Additionally, the time of receipt of the inquiry will be documented. We
+            process this data to address your inquiry (e.g., to assist with any questions regarding our projects,
+            informing you on how to support us, query about volunteering etc.).
+          </p>
+          <p class="text-center mb-48">
+            For website users in the EEA, the legal basis for this data processing is our legitimate interest under
+            Article 6(1)(f) of the GDPR in addressing your inquiry or, if your inquiry is aimed at the conclusion or
+            performance of a contract, in the implementation of the necessary measures within the meaning of Article
+            6(1)(b) of the GDPR.
+          </p>
+
+          <h3 class="text-center mb-24">Newsletter Subscription</h3>
+          <p class="text-center mb-24">
+            If you register for our newsletter on our website, we collect your email address. To prevent misuse and
+            ensure that the owner of an email address has genuinely given consent, we use a double-opt-in process. After
+            submitting your registration, you will receive an email containing a confirmation link. You must click on
+            this link to finalize your registration. If you do not confirm your email address within the specified
+            timeframe, your data will be deleted, and no newsletters will be sent.
+          </p>
+          <p class="text-center mb-24">
+            Our newsletter service is powered by the platform Ghost (Ghost Foundation Ltd, Singapore), which facilitates
+            both the delivery of emails to your inbox and the hosting of our newsletter content at <a
+              style="color: inherit;font-weight:600"
+              href="https://newsletter.openhomefoundation.org/">https://newsletter.openhomefoundation.org/</a>. If you
+            access the newsletter through the Ghost platform, technical data (limited to IP address and browser
+            information) may be processed by Ghost to display the content correctly and ensure system stability.
+          </p>
+          <p class="text-center mb-24">
+            For website users in the EEA, the legal basis for the processing of personal data in connection with the
+            newsletter and the statistical analysis of user behavior is your consent pursuant to Article 6(1)(a) GDPR.
+            You may withdraw your consent at any time.
+          </p>
+          <p class="text-center mb-24">
+            For newsletter service, we use the applications provided by Ghost. Therefore, your data may be stored in a
+            database of Ghost, which may allow Ghost to access your data if this is necessary for providing the software
+            and supporting its use. For website users in the EEA, the legal basis for this processing is our legitimate
+            interest within the meaning of Article 6(1)(f) of the GDPR in using the services of third-party providers.
+          </p>
+          <p class="text-center mb-48">
+            There is a possibility that Ghost may want to use some of this data for its own purposes (e.g., conducting
+            statistical analysis). For these data processing activities, Ghost is the controller and must ensure
+            compliance of these processing activities with data protection laws. Information about data processing by
+            Ghost can be found at <a style="color: inherit;font-weight:600"
+              href="https://ghost.org/privacy/">https://ghost.org/privacy/</a>.
+          </p>
+
+          <h3 class="text-center mb-24">Job applications</h3>
+          <p class="text-center mb-24">
+            You can apply for a position in our foundation either spontaneously or in response to a specific job
+            advertisement. In both cases, we will process the personal data you provide us with, such as your name,
+            contact details, CV information (including education and work history), links or portfolios, and any answers
+            or documents you upload as part of the application process.
+          </p>
+          <p class="text-center mb-24">
+            We use this data to assess your application and suitability for employment. For applicants in the EEA, the
+            legal basis for this data processing is the implementation of the necessary pre-contractual or contractual
+            measures within the meaning of Article 6(1)(b) of the GDPR.
+          </p>
+          <p class="text-center mb-24">
+            Application documents from unsuccessful applicants will be deleted at the end of the application process,
+            unless you explicitly agree to a longer retention period or we are legally obliged to retain them for a
+            longer period. For applicants in the EEA, the legal basis for this data processing is your consent within the
+            meaning of Article 6(1)(a) of the GDPR. You may withdraw your consent anytime.
+          </p>
+          <p class="text-center mb-48">
+            For the processing of applications, we use services provided by Ashby, Inc., 548 Market St PMP 397006, San
+            Francisco, CA 94104-5401, USA. Therefore, your data may be stored in a database of Ashby, which may allow
+            Ashby to access your data if this is necessary for providing the software and supporting its use. Information
+            about data processing by Ashby can be found at <a style="color: inherit;font-weight:600"
+              href="https://www.ashbyhq.com/resources/privacy">https://www.ashbyhq.com/resources/privacy</a>. For website
+            users in the EEA, the legal basis for this processing is our legitimate interest within the meaning of
+            Article 6(1)(f) of the GDPR in using the services of third-party providers.
+          </p>
+
+          <h3 class="text-center mb-24">Participation in user research</h3>
+          <p class="text-center mb-24">
+            We occasionally invite users to participate in research studies to improve our projects. Participation is
+            entirely voluntary. When you participate, we process the data you provide (such as feedback, usage habits, or
+            contact details) in accordance with the specific research privacy notice provided to you at the start of each
+            study (cf. also <a style="color: inherit;font-weight:600"
+              href="https://www.openhomefoundation.org/user-research-agreement/">here</a>).
+          </p>
+          <p class="text-center mb-48">
+            The legal basis for the processing of personal data in connection with participation in user research is your
+            consent pursuant to Article 6(1)(a) GDPR. You may withdraw your consent at any time.
+          </p>
+
+          <h3 class="text-center mb-24">Volunteer reimbursements</h3>
+          <p class="text-center mb-24">
+            If you volunteer for the Open Home Foundation and request reimbursement for expenses, we process the personal
+            data necessary to review and execute the reimbursement. This includes your name, contact details, address,
+            bank account information, and any documentation you submit (e.g., receipts or supporting records).
+          </p>
+          <p class="text-center mb-48">
+            We use this data to verify your reimbursement request, contact you in case of questions, and execute the
+            payment of the reimbursement. For volunteers in the EEA, the legal basis for this data processing is our
+            legitimate interest pursuant to Article 6(1)(f) GDPR in managing reimbursements and supporting volunteer
+            participation. Where reimbursement relates to an existing contractual relationship, the legal basis is
+            Article 6(1)(b) GDPR. For the processing of reimbursements, we may use external service providers (such as
+            banking institutes, payment processors or accounting services). Therefore, your data may be processed by
+            these providers if necessary for providing their services. For volunteers in the EEA, the legal basis for
+            this processing is our legitimate interest within the meaning of Article 6(1)(f) GDPR in using the services
+            of third-party providers.
+          </p>
+
+          <h3 class="text-center mb-24">Support us</h3>
+          <p class="text-center mb-24">
+            The Open Home Foundation is funded by commercial partner fees and donations. Our website provides links to
+            external platforms such as GitHub Sponsors, Ko-fi, or other sponsorship services. When you click these
+            links, you are redirected to the respective provider's platform, and those providers act as independent
+            controllers for any data you provide to them. The legal basis for the processing of personal data in
+            connection with providing links to these external sponsorship platforms is our legitimate interest in
+            facilitating support for our projects pursuant to Article 6(1)(f) GDPR.
+          </p>
+          <p class="text-center mb-48">
+            Furthermore, you may support our work by purchasing products or subscribing to services through our
+            commercial partners, such as Nabu Casa and Apollo Automation. These transactions are handled exclusively by
+            the respective partner under their own privacy policies. The Open Home Foundation does not receive your
+            payment or purchase data from these partners; we only receive the resulting partner fees which are used to
+            fund our operations.
+          </p>
+
+          <h3 class="text-center mb-24">Visitor data and analytics</h3>
+          <p class="text-center mb-24">
+            We collect minimal personal data when you visit our website, which is processed for two main purposes:
+            website stability + security, and usage analysis.
+          </p>
+          <p class="text-center mb-24">
+            <strong>Website Stability and Security (Cloudflare)</strong><br />
+            Our websites are served via Cloudflare (Cloudflare, Inc.), our Content Delivery Network (CDN). Cloudflare
+            processes minimal usage data, such as your IP address and pages visited, to ensure the long-term security and
+            stability of the system, establish a connection, and carry out basic traffic analysis, such as the number of
+            visits to each page. This data is not used for tracking or profiling.
+          </p>
+          <p class="text-center mb-24">
+            <strong>Website Analytics (Self-Hosted Plausible)</strong><br />
+            For a more detailed understanding of site usage and activity, we plan to use Plausible analytics. We will
+            self-host the Plausible analytics platform on our own infrastructure, which means we will maintain full
+            ownership and control, and all collected data will stay on our own servers. No data will be shared with
+            Plausible Insights OÜ, the Plausible company, or any other third party. Plausible collects data anonymously
+            and in aggregate. It is designed to be privacy-first and does not use cookies, store IP addresses, or collect
+            personal data, persistent identifiers, or cross-site tracking.
+          </p>
+          <p class="text-center mb-24">
+            The data we will collect and process for analytics includes:
+          </p>
+          <ul class="mb-24">
+            <li>Information about your browser, network, and device</li>
+            <li>Web pages you visited prior to coming to this website</li>
+            <li>Web pages you view while on this website</li>
+            <li>Approximate country/region (derived from your IP address, which is immediately discarded and never
+              stored)</li>
+          </ul>
+          <p class="text-center mb-24">
+            This information may also include aggregate details about your use of this website, for error and performance
+            analysis and optimization:
+          </p>
+          <ul class="mb-24">
+            <li>Clicks</li>
+            <li>Internal links</li>
+            <li>Scrolling/Scroll depth</li>
+            <li>Searches</li>
+            <li>Timestamps/Time on page</li>
+            <li>Referral sources</li>
+          </ul>
+          <p class="text-center mb-48">
+            For website visitors from the EEA, the legal basis for this data processing is our legitimate interest within
+            the meaning of Article 6(1)(f) of the GDPR in the purposes described above.
+          </p>
+
+          <h3 class="text-center mb-24">Social Network Profiles</h3>
+          <p class="text-center mb-24">
+            Our website contains links to our profiles on the social networks of the following providers:
+          </p>
+          <ul class="mb-24">
+            <li>Fosstodon Foundation, <a style="color: inherit;font-weight:600"
+                href="https://fosstodon.org/privacy-policy">Privacy Policy</a>;</li>
+            <li>Bluesky Social, PBC, 113 Cherry St, Seattle, WA 98104, United States, <a
+                style="color: inherit;font-weight:600" href="https://bsky.social/about/support/privacy-policy">Privacy
+                Policy</a>;</li>
+            <li>GitHub B.V., Prins Bernhardplein 200, Amsterdam 1097JB, the Netherlands and GitHub, Inc., 88 Colin P.
+              Kelly Jr. St., San Francisco, CA 94107, United States, <a style="color: inherit;font-weight:600"
+                href="https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement">Privacy
+                Policy</a>.</li>
+          </ul>
+          <p class="text-center mb-24">
+            If you click on the icons of the social networks, you will be automatically redirected to our profile on the
+            respective network. This establishes a direct connection between your browser and the server of the
+            respective social network. As a result, the social network receives information that you have visited our
+            website with your IP address and clicked on the link. This may also involve the transfer of data to servers
+            abroad, e.g., in the USA (for information on the absence of an adequate level of data protection and the
+            proposed safeguards, see the Section below on International Data Transfers).
+          </p>
+          <p class="text-center mb-48">
+            If you click on a link to a social network while you are logged into your user account on that social
+            network, the content of our website can be associated with your profile, allowing the social network to
+            directly link your visit to our website to your account. If you want to prevent this, please log out of your
+            account before clicking on the respective links. A connection between your access to our website and your
+            user account will always be established if you log in to the respective social network after clicking on the
+            link. The data processing associated with this is the responsibility of the respective provider in terms of
+            data protection. Therefore, please refer to the privacy notices on the social network's website.
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="privacy-international-transfers">
+    <div class="container">
+      <div class="grid">
+        <div class="col-s-12 col-m-8 col-m-offset-3">
+          <h2 class="text-center mb-48">International Data Transfers</h2>
+          <p class="text-center mb-24">
+            We operate from Switzerland. Our website uses service providers (e.g., Ashby, Inc. for job applications).
+            These service providers are in some cases located in countries outside Switzerland, for example in the United
+            States. Consequently, your personal data may be transferred to and processed in countries outside of
+            Switzerland and the European Economic Area (EEA) that do not provide an adequate level of data protection
+            from a Swiss or EU perspective.
+          </p>
+          <p class="text-center mb-48">
+            We ensure the transfers of data to the United States rely on legal frameworks recognized by the Swiss
+            Federal Data Protection and Information Commissioner (FDPIC) and the European Commission, such as the Data
+            Privacy Framework (DPF) or Standard Contractual Clauses (SCCs) and will, if necessary, ensure additional
+            appropriate safeguards are in place so that your data is adequately protected at our third-party service
+            providers.
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="privacy-retention">
+    <div class="container">
+      <div class="grid">
+        <div class="col-s-12 col-m-8 col-m-offset-3">
+          <h2 class="text-center mb-48">Retention Periods</h2>
+          <p class="text-center mb-24">
+            We only store personal data for as long as it is necessary to carry out the processing described in this
+            privacy policy within the scope of our legitimate interests.
+          </p>
+          <p class="text-center mb-48">
+            For contractual data, we are required by law to retain business communication, concluded contracts, and
+            accounting documents. According to these regulations, records must be retained for up to 10 years. If we no
+            longer need this data to provide services for you, the data will be blocked. This means that the data may
+            then only be used if this is necessary to fulfil the retention obligations or to defend and enforce our legal
+            interests. The data will be deleted as soon as there is no longer any legal obligation to retain it and no
+            legitimate interest in its retention exists.
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="privacy-rights">
+    <div class="container">
+      <div class="grid">
+        <div class="col-s-12 col-m-8 col-m-offset-3">
+          <h2 class="text-center lh-normal mb-32">Your Rights</h2>
+          <p class="text-center mb-48">
+            Under the GDPR and FADP, you have the right to:
+          </p>
+        </div>
+      </div>
+      <div class="grid">
+        <div class="col-s-12 col-m-6">
+          <div class="item primary text-center p-32">
+            <h3 class="mb-24">Access</h3>
+            <p class="text-secondary">
+              Ask for information at any time and free of charge about your personal data stored by us.
+            </p>
+          </div>
+        </div>
+        <div class="col-s-12 col-m-6">
+          <div class="item primary text-center p-32">
+            <h3 class="mb-24">Correction</h3>
+            <p class="text-secondary">
+              Ask us to fix incorrect data.
+            </p>
+          </div>
+        </div>
+        <div class="col-s-12 col-m-6">
+          <div class="item primary text-center p-32">
+            <h3 class="mb-24">Deletion</h3>
+            <p class="text-secondary">
+              Ask us to delete your data. Under certain circumstances this right may not be available, for example where
+              we are legally required to keep data records.
+            </p>
+          </div>
+        </div>
+        <div class="col-s-12 col-m-6">
+          <div class="item primary text-center p-32">
+            <h3 class="mb-24">Restriction</h3>
+            <p class="text-secondary">
+              Ask us to limit how we use your data.
+            </p>
+          </div>
+        </div>
+        <div class="col-s-12 col-m-6">
+          <div class="item primary text-center p-32">
+            <h3 class="mb-24">Portability</h3>
+            <p class="text-secondary">
+              Receive your data in a structured, commonly used format.
+            </p>
+          </div>
+        </div>
+        <div class="col-s-12 col-m-6">
+          <div class="item primary text-center p-32">
+            <h3 class="mb-24">Withdraw consent</h3>
+            <p class="text-secondary">
+              Where the legal basis for processing your data is your consent, you have the right to withdraw that consent
+              at any time. However, processing activities based on your consent in the past will not become unlawful due
+              to your withdrawal.
+            </p>
+          </div>
+        </div>
+      </div>
+      <div class="grid">
+        <div class="col-s-12 col-m-8 col-m-offset-3">
+          <p class="text-center mt-24 mb-48">
+            To exercise any of these rights, please contact us at <a style="color: inherit;font-weight:600"
+              href="mailto:hello@openhomefoundation.org">hello@openhomefoundation.org</a>.
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="privacy-effective-date">
+    <div class="container">
+      <div class="grid">
+        <div class="col-s-12 col-m-8 col-m-offset-3">
+          <h2 class="text-center mb-32">Effective Date</h2>
+          <p class="text-center mb-48">
+            This privacy policy was last updated on 2026-05-07.
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+</div>

--- a/src/privacy-policy.html
+++ b/src/privacy-policy.html
@@ -20,17 +20,17 @@ title: Privacy Policy
           </p>
           <p class="text-center mb-24">
             Privacy is one of the Open Home Foundation's three fundamental <a style="color: inherit;font-weight:600"
-              href="https://www.openhomefoundation.org/">principles</a> that are at the core of everything we do. It is
-            therefore that we collect as minimal of data as possible and where we do, we do this with a preference of
-            self-hosted and/or privacy focused tools.
+              href="https://www.openhomefoundation.org/">principles</a> that are at the core of everything we do. We
+            therefore minimize the amount of data we collect as much as possible, and where we do collect data, it is
+            done with a preference for self-hosted and/or privacy focused tools.
           </p>
           <p class="text-center mb-24">
             Please note that this Privacy Policy is applicable only to the Open Home Foundation official website, hosted
             at openhomefoundation.org, and any activities that are provided directly from this website domain such as
-            email contact, our newsletter or participation in one of our research activities.
+            email contact, our newsletter, or participation in one of our research activities.
           </p>
           <p class="text-center mb-24">
-            Products/projects (such as Home Assistant, ESPHome and Music Assistant) of the Open Home Foundation and
+            Products/projects (such as Home Assistant, ESPHome, and Music Assistant) of the Open Home Foundation and
             their respective websites have their own Privacy Policy or have one in the making (where applicable) but
             these are out of scope for this document.
           </p>
@@ -137,8 +137,8 @@ title: Privacy Policy
             We occasionally invite users to participate in research studies to improve our projects. Participation is
             entirely voluntary. When you participate, we process the data you provide (such as feedback, usage habits, or
             contact details) in accordance with the specific research privacy notice provided to you at the start of each
-            study (cf. also <a style="color: inherit;font-weight:600"
-              href="https://www.openhomefoundation.org/user-research-agreement/">here</a>).
+            study (see also our <a style="color: inherit;font-weight:600"
+              href="https://www.openhomefoundation.org/user-research-agreement/">User Research Agreement</a>).
           </p>
           <p class="text-center mb-48">
             The legal basis for the processing of personal data in connection with participation in user research is your
@@ -183,7 +183,7 @@ title: Privacy Policy
           <h3 class="text-center mb-24">Visitor data and analytics</h3>
           <p class="text-center mb-24">
             We collect minimal personal data when you visit our website, which is processed for two main purposes:
-            website stability + security, and usage analysis.
+            website stability and security, and usage analysis.
           </p>
           <p class="text-center mb-24">
             <strong>Website Stability and Security (Cloudflare)</strong><br />


### PR DESCRIPTION
## Summary
This PR adds a comprehensive Privacy Policy page to the Open Home Foundation website and includes a link to it in the footer navigation.

## Key Changes
- **New Privacy Policy page** (`src/privacy-policy.html`): A detailed 400-line privacy policy document covering:
  - Introduction and summary of data protection principles
  - Data processing activities including contact forms, newsletter subscriptions, job applications, user research, volunteer reimbursements, and donation support
  - Information about analytics (Cloudflare for stability, self-hosted Plausible for analytics)
  - Third-party service providers (Ghost, Ashby, etc.) and their data handling
  - International data transfer safeguards
  - Data retention periods
  - User rights under GDPR and Swiss FADP
  - Effective date (2026-05-07)

- **Footer navigation update**: Added a "Privacy Policy" link in the footer component (`src/_includes/components/footer.liquid`) to make the policy easily accessible from all pages

## Implementation Details
- The privacy policy is structured with clear sections using semantic HTML headings and grid layout classes consistent with the site's design system
- Complies with both Swiss Federal Act on Data Protection (FADP) and EU GDPR requirements
- Emphasizes the foundation's commitment to privacy as a core principle
- Provides transparent information about data collection, processing, and user rights
- Includes links to third-party privacy policies and contact information for data subject requests

https://claude.ai/code/session_01VkEtQ9DXXHJv1BGSeDkqH7