### PR TITLE
Add IT Policy document to governance section

### DIFF
--- a/_data/documents.yml
+++ b/_data/documents.yml
@@ -55,6 +55,9 @@ sections:
       - title: "Collaboration Members Regulations"
         description: "Establish the framework for external open source projects to support the Open Home Foundation's mission."
         link: "https://drive.google.com/file/d/1ss_2ejQB9gYrTyBaMnHxmhReNHbalWoS/view"
+      - title: "IT Policy"
+        description: "Set the standards for the secure and responsible use of the Open Home Foundation's IT systems, devices, and data."
+        link: "https://drive.google.com/file/d/1HJzYJGCaH0Dmvq7gt0VDinEyjA3YaWmt/view"
   - title: "Budgets"
     description: "This section contains the annual budget for the Open Home Foundation, as approved by the Board."
     documents:

--- a/_data/documents.yml
+++ b/_data/documents.yml
@@ -56,7 +56,7 @@ sections:
         description: "Establish the framework for external open source projects to support the Open Home Foundation's mission."
         link: "https://drive.google.com/file/d/1ss_2ejQB9gYrTyBaMnHxmhReNHbalWoS/view"
       - title: "IT Policy"
-        description: "Set the standards for the secure and responsible use of the Open Home Foundation's IT systems, devices, and data."
+        description: "Defines the mandatory and recommended security principles and establish the rules for the secure and appropriate use of electronic data and IT resources within the Open Home Foundation."
         link: "https://drive.google.com/file/d/1HJzYJGCaH0Dmvq7gt0VDinEyjA3YaWmt/view"
   - title: "Budgets"
     description: "This section contains the annual budget for the Open Home Foundation, as approved by the Board."


### PR DESCRIPTION
## Summary
Added the IT Policy document to the governance documents section of the website.

## Changes
- Added new IT Policy document entry to the governance section in `_data/documents.yml`
  - Title: "IT Policy"
  - Description: Standards for secure and responsible use of Open Home Foundation's IT systems, devices, and data
  - Link: Google Drive document reference

## Details
The IT Policy document has been added as the fourth item in the governance documents list, positioned after the Collaboration Members Regulations. This document establishes guidelines for IT system usage and data security within the organization.

https://claude.ai/code/session_01FUFzBmTGqrPm9Y7rTgKDH4