### PR TITLE
Add Discourse comments

### DIFF
--- a/_data/env.js
+++ b/_data/env.js
@@ -1,0 +1,5 @@
+module.exports = {
+  // Cloudflare Pages exposes the branch being built via CF_PAGES_BRANCH.
+  // Production is deployed from the `main` branch.
+  isProduction: process.env.CF_PAGES_BRANCH === "main",
+};

--- a/src/_includes/post.liquid
+++ b/src/_includes/post.liquid
@@ -17,7 +17,34 @@ layout: base
           {% if author %}
             <p class="meta text-center">
               <span class="meta-secondary">{{ date | date: '%A, %B %d, %Y' }} · {{ reading_time }} minute read</span>
-              <span class="meta-author"><span class="author-avatars">{% for slug in author %}{% assign a = authors[slug] %}{% if a.github %}<img class="author-avatar" src="https://github.com/{{ a.github }}.png?size=80" alt="{{ a.name }}">{% elsif a.avatar %}<img class="author-avatar" src="{{ a.avatar }}" alt="{{ a.name }}">{% endif %}{% endfor %}</span><span class="author-names">{% for slug in author %}{% assign a = authors[slug] %}{% if a %}{% if a.github %}<a href="https://github.com/{{ a.github }}" target="_blank" rel="noopener noreferrer">{{ a.name }}</a>{% else %}{{ a.name }}{% endif %}{% else %}{{ slug }}{% endif %}{% unless forloop.last %}, {% endunless %}{% endfor %}</span></span>
+              <span class="meta-author"
+                ><span class="author-avatars">
+                  {%- for slug in author -%}
+                    {%- assign a = authors[slug] -%}
+                    {%- if a.github -%}
+                      <img class="author-avatar" src="https://github.com/{{ a.github }}.png?size=80" alt="{{ a.name }}">
+                    {%- elsif a.avatar -%}
+                      <img class="author-avatar" src="{{ a.avatar }}" alt="{{ a.name }}">
+                    {%- endif -%}
+                  {%- endfor -%}></span
+                ><span class="author-names">
+                  {%- for slug in author -%}
+                    {%- assign a = authors[slug] -%}
+                    {%- if a -%}
+                      {%- if a.github -%}
+                        <a href="https://github.com/{{ a.github }}" target="_blank" rel="noopener noreferrer">
+                          {{- a.name -}}
+                        </a>
+                      {%- else -%}
+                        {{- a.name -}}
+                      {%- endif -%}
+                    {%- else -%}
+                      {{- slug -}}
+                    {%- endif -%}
+                    {%- unless forloop.last %}, {% endunless -%}
+                  {%- endfor -%}
+                </span></span
+              >
             </p>
           {% else %}
             <p class="meta text-center">
@@ -43,9 +70,26 @@ layout: base
       {% endif %}
       <div class="grid">
         <div class="col-s-12 col-m-8 col-m-offset-3">
-          <div class="content mb-128">
+          <div class="content{% unless comments == true and env.isProduction %} mb-128{% endunless %}">
             {{ content }}
           </div>
+          {% if comments == true and env.isProduction %}
+            <div id="discourse-comments" class="mb-128"></div>
+            <script type="text/javascript">
+              DiscourseEmbed = {
+                discourseUrl: 'https://community.home-assistant.io/',
+                discourseEmbedUrl: 'https://www.openhomefoundation.org{{ page.url }}',
+              };
+
+              (function () {
+                var d = document.createElement('script');
+                d.type = 'text/javascript';
+                d.async = true;
+                d.src = DiscourseEmbed.discourseUrl + 'javascripts/embed.js';
+                (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(d);
+              })();
+            </script>
+          {% endif %}
         </div>
       </div>
     </div>

--- a/src/blog/building-the-device-database-together.md
+++ b/src/blog/building-the-device-database-together.md
@@ -9,6 +9,7 @@ hide_header_image: true
 date: 2026-07-23
 author: [matthias-kerstner]
 category: "Announcements"
+comments: true
 ---
 
 Ever since we introduced the idea of a community-powered device database at State of the Open Home 2025, our goal has been clear: create a “Wikipedia of smart home devices” based on real-world usage. In February, we took the first step by <a href="https://www.home-assistant.io/blog/2026/02/02/about-device-database/" target="_blank" rel="noopener noreferrer">inviting Home Assistant users</a> to voluntarily share anonymized device data to help us build it.


### PR DESCRIPTION
- Adds the Discourse comments that puts all blog posts under https://community.home-assistant.io/c/blog/open-home-foundation/62
- Enables comments to the latest blog (Device database)
- Comments only show when deployed to production