### PR TITLE
Allow blog post tables to scroll horizontally on mobile

### DIFF
--- a/src/assets/css/pages/blog.css
+++ b/src/assets/css/pages/blog.css
@@ -151,13 +151,21 @@
 }
 
 #post .content table {
-  width: 100%;
+  display: block;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
   border-collapse: collapse;
   margin-top: 24px;
   margin-bottom: 24px;
   font-size: 16px;
   font-weight: 300;
   color: var(--secondary-text-color);
+}
+
+@media (min-width: 768px) {
+  #post .content table {
+    width: 100%;
+  }
 }
 
 #post .content th,

--- a/src/assets/css/pages/blog.css
+++ b/src/assets/css/pages/blog.css
@@ -174,6 +174,7 @@
   text-align: left;
   vertical-align: top;
   border-bottom: 1px solid var(--light-grey-color);
+  min-width: 220px;
 }
 
 #post .content th:first-child,


### PR DESCRIPTION
Tables in blog content (e.g. the Plausible analytics post) were
squishing their columns to fit narrow viewports. Let the table
overflow and scroll horizontally instead, keeping the full-width
layout on desktop.